### PR TITLE
updates on ij2xy()

### DIFF
--- a/pytileproj/base.py
+++ b/pytileproj/base.py
@@ -1344,10 +1344,13 @@ class Tile(object):
         return geot
 
 
-    def ij2xy(self, i, j, lowerleft=False):
+    def ij2xy(self, i, j, lowerleft=False, offset='center'):
         """
         Returns the projected coordinates of a tile pixel in the TilingSystem
         for a given pixel pair defined by column and row (pixel indices)
+
+        By default, the pixels center is returned (this can be changed
+        by setting 'offset' to one of 'll', 'lr', 'ul', 'ur')
 
         columns go from left to right
         rows go either
@@ -1363,6 +1366,10 @@ class Tile(object):
         lowerleft : bool, optional
             should the row numbering start at the bottom?
             If yes, it returns lowerleft indices.
+        offset : str, optional
+            location of the returned coordinates.
+            possible values are: ('ll', 'lr', 'ul', 'ur', 'center')
+            The default is 'center'.
 
         Returns
         -------
@@ -1379,6 +1386,41 @@ class Tile(object):
 
         x = gt[0] + i * gt[1] + j * gt[2]
         y = gt[3] + i * gt[4] + j * gt[5]
+
+        assert offset in ['ll', 'lr', 'ul', 'ur', 'center'], (
+            "offset must be one of ['ll', 'lr', 'ul', 'ur', 'center']")
+
+
+        if offset == 'center':
+            xcenterpos = gt[1] / 2
+            ycenterpos = gt[5] / 2
+            # use integers if possible
+            if xcenterpos.is_integer(): xcenterpos = int(xcenterpos)
+            if ycenterpos.is_integer(): ycenterpos = int(ycenterpos)
+
+            x += xcenterpos
+            y += ycenterpos
+
+        else:
+            if lowerleft:
+                if offset == 'ul':
+                    y += gt[5]
+                if offset == 'ur':
+                    y += gt[5]
+                    x += gt[1]
+                if offset == 'll': pass
+                if offset == 'lr':
+                    x += gt[1]
+            else:
+                if offset == 'ul': pass
+                if offset == 'ur':
+                    x += gt[1]
+                if offset == 'll':
+                    y += gt[5]
+                if offset == 'lr':
+                    x += gt[1]
+                    y += gt[5]
+
 
         if self.core.sampling <= 1.0:
             precision = len(str(int(1.0 / self.core.sampling))) + 1

--- a/pytileproj/base.py
+++ b/pytileproj/base.py
@@ -466,7 +466,7 @@ class TiledProjectionSystem(object):
             print("Error: Either roi_geometry, bbox, or points must be given "
                   "as the region-of-interest!")
             return list()
-        
+
 
         # obtain the ROI
         if roi_geometry is None:
@@ -559,7 +559,7 @@ class TiledProjectionSystem(object):
                 roi_polygons.append(poly)
         else:
             roi_polygons = [roi_geometry]
-        
+
         overlapped_tiles = list()
         for roi_polygon in roi_polygons:
             # intersect the given grid ids and the overlapped ids
@@ -1357,9 +1357,9 @@ class Tile(object):
         Parameters
         ----------
         i : number
-            pixel row number
+            pixel column number
         j : number
-            pixel collumn number
+            pixel row number
         lowerleft : bool, optional
             should the row numbering start at the bottom?
             If yes, it returns lowerleft indices.

--- a/tests/test_utmgrid.py
+++ b/tests/test_utmgrid.py
@@ -153,7 +153,7 @@ class TestBaseViaUTMGrid(unittest.TestCase):
         x_should = 481500
         y_should = 9270500
         tile = utm.Z18N.tilesys.create_tile(x=481746, y=9270569)
-        x, y = tile.ij2xy(963, 659)
+        x, y = tile.ij2xy(963, 659, offset='ul')
         nptest.assert_allclose(x_should, x)
         nptest.assert_allclose(y_should, y)
 


### PR DESCRIPTION
- the first commit fixes the documentation (i corresponds to the column, not to the row!)

- the second commit addresses the fact that the position of the returned coordinates from `ij2xy()` is not entirely clear...
The current behaviour is:
   - with `lowerleft = True` , the lower-left corner is returned
   - with `lowerleft = False`, the upper-left corner is returned

I've added a first implementation of an `offset` option in analogy to rasterio's `.xy()` function   [(see doc here)](https://rasterio.readthedocs.io/en/latest/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.xy) that allows specifying the location of the returned coordinates within the pixel. 
The default is set to `'center'` (again in analogy to rasterio) which is also what I would expect to get when i want the coordinates of a pixel based on row-column values.
